### PR TITLE
Upgrade jenkins to avoid slow download

### DIFF
--- a/base/jenkins/install.sls
+++ b/base/jenkins/install.sls
@@ -7,7 +7,7 @@ jenkins:
   pkg.installed:
     - hold: True
     - sources:
-      - jenkins: http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_1.651.1_all.deb
+      - jenkins: http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_1.651.3_all.deb
 
 disable-jenkins-service:
   service.dead:


### PR DESCRIPTION
This upgrades the jenkins version that is installed ony a tiny bit, because the currently used one takes around 3 hours to download (which seems to be an issue on the server side). The newer version seems to be faster, according to Vladimir Voronin.